### PR TITLE
Swift 3 Renaming

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project: yes
+    patch: no
+    changes: no

--- a/Dangerfile
+++ b/Dangerfile
@@ -2,23 +2,23 @@
 
 # Sometimes it's a README fix, or something like that - which isn't relevant for
 # including in a project's CHANGELOG for example
-declared_trivial = (github.pr_title + github.pr_body).include?("#trivial")
+declared_trivial = (github.pr_title + github.pr_body).include? "#trivial"
 
 # Make it more obvious that a PR is a work in progress and shouldn't be merged yet
-warn("PR is classed as Work in Progress") if pr_title.include? "[WIP]"
+warn "PR is classed as Work in Progress" if github.pr_title.include? "[WIP]"
 
 # Warn when there is a big PR
-warn("Big PR") if lines_of_code > 500
+warn "Big PR" if git.lines_of_code > 500
 
 # Ensure there is a summary for a PR
 fail "Please provide a summary in the Pull Request description" if github.pr_body.length < 5
 
 # Add a CHANGELOG entry for app changes
-if git.lines_of_code > 50 && !github.modified_files.include?("CHANGELOG.md") && !declared_trivial
-  fail("Please update [CHANGELOG.md](https://github.com/polydice/iCook-tvOS/blob/develop/CHANGELOG.md).")
+if git.lines_of_code > 50 && !git.modified_files.include?("CHANGELOG.md") && !declared_trivial
+  fail "Please update [CHANGELOG.md](https://github.com/polydice/iCook-tvOS/blob/develop/CHANGELOG.md).", sticky: true
 end
 
 # Ensure a clean commits history
 if git.commits.any? { |c| c.message =~ /^Merge branch/ }
-  fail('Please rebase to get rid of the merge commits in this PR')
+  fail "Please rebase to get rid of the merge commits in this PR", sticky: true
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    CFPropertyList (2.3.3)
+    CFPropertyList (2.3.4)
     RubyInline (3.12.4)
       ZenTest (~> 4.3)
     ZenTest (4.11.1)
@@ -12,7 +12,6 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.4.0)
-    babosa (1.0.2)
     claide (1.0.1)
     claide-plugins (0.9.2)
       cork
@@ -64,7 +63,7 @@ GEM
       commander (>= 4.3.5)
       highline (>= 1.7.1)
       security
-    danger (4.0.0)
+    danger (4.0.1)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored (~> 1.2)
@@ -82,8 +81,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (1.3.1)
       faraday (~> 0.8)
-    fastlane_core (0.53.0)
-      babosa
+    fastlane_core (0.57.2)
       colored
       commander (>= 4.4.0, <= 5.0.0)
       credentials_manager (>= 0.16.2, < 1.0.0)
@@ -102,13 +100,13 @@ GEM
     highline (1.7.8)
     i18n (0.7.0)
     json (1.8.3)
-    kramdown (1.12.0)
+    kramdown (1.13.1)
     mini_portile2 (2.1.0)
-    minitest (5.9.1)
-    molinillo (0.5.2)
+    minitest (5.10.1)
+    molinillo (0.5.4)
     multi_json (1.12.1)
     multipart-post (2.0.0)
-    nanaimo (0.2.2)
+    nanaimo (0.2.3)
     nap (1.1.0)
     netrc (0.7.8)
     nokogiri (1.6.8.1)
@@ -124,8 +122,8 @@ GEM
     sawyer (0.7.0)
       addressable (>= 2.3.5, < 2.5)
       faraday (~> 0.8, < 0.10)
-    scan (0.14.1)
-      fastlane_core (>= 0.53.0, < 1.0.0)
+    scan (0.14.2)
+      fastlane_core (>= 0.57.0, < 1.0.0)
       slack-notifier (~> 1.3)
       terminal-table (>= 1.4.5, < 2.0.0)
       xcpretty (>= 0.2.4, < 1.0.0)

--- a/iCookTV/Controllers/CategoriesViewController.swift
+++ b/iCookTV/Controllers/CategoriesViewController.swift
@@ -56,7 +56,7 @@ class CategoriesViewController: UIViewController,
 
   // MARK: - BlurBackgroundPresentable
 
-  let imageAnimationQueue = ImageAnimationQueue(imageView: UIImageView())
+  let backgroundImageView = UIImageView()
 
   // MARK: - Initialization
 

--- a/iCookTV/Controllers/HistoryViewController.swift
+++ b/iCookTV/Controllers/HistoryViewController.swift
@@ -39,7 +39,7 @@ class HistoryViewController: UIViewController,
 
   // MARK: - BlurBackgroundPresentable
 
-  let imageAnimationQueue = ImageAnimationQueue(imageView: UIImageView())
+  let backgroundImageView = UIImageView()
 
   // MARK: - DropdownMenuPresentable
 

--- a/iCookTV/Controllers/VideosViewController.swift
+++ b/iCookTV/Controllers/VideosViewController.swift
@@ -56,7 +56,7 @@ class VideosViewController: UIViewController,
 
   // MARK: - BlurBackgroundPresentable
 
-  let imageAnimationQueue = ImageAnimationQueue(imageView: UIImageView())
+  let backgroundImageView = UIImageView()
 
   // MARK: - DataFetching
 

--- a/iCookTV/Extensions/CGRect+Grid.swift
+++ b/iCookTV/Extensions/CGRect+Grid.swift
@@ -26,7 +26,7 @@
 
 import UIKit
 
-enum Grid: Int {
+enum Grid: Int, Equatable {
   case topLeft, topRight, bottomLeft, bottomRight
 
   static let numberOfGrids: Int = {
@@ -34,17 +34,18 @@ enum Grid: Int {
     while let _ = Grid(rawValue: count) { count += 1 }
     return count
   }()
-}
 
-func == (lhs: Grid, rhs: Grid) -> Bool {
-  return lhs.rawValue == rhs.rawValue
+  static func == (lhs: Grid, rhs: Grid) -> Bool {
+    return lhs.rawValue == rhs.rawValue
+  }
+
 }
 
 extension CGRect {
 
-  func rect(bySize size: CGSize, atCorner corner: Grid) -> CGRect {
+  func rect(with size: CGSize, in grid: Grid) -> CGRect {
     let target = CGSize(width: min(width, size.width), height: min(height, size.height))
-    switch corner {
+    switch grid {
     case .topLeft:
       return divided(atDistance: target.height, from: .maxYEdge).remainder.divided(atDistance: target.width, from: .maxXEdge).remainder
     case .topRight:

--- a/iCookTV/Extensions/UIFont+TV.swift
+++ b/iCookTV/Extensions/UIFont+TV.swift
@@ -35,34 +35,34 @@ extension UIFont {
 
   // MARK: - Private Methods
 
-  private class func tvFontOfSize(_ fontSize: CGFloat) -> UIFont {
+  private class func tvFont(ofSize fontSize: CGFloat) -> UIFont {
     return UIFont(name: FontFamily.PingFangTCRegular, size: fontSize) ?? UIFont.systemFont(ofSize: fontSize)
   }
 
-  private class func tvBoldFontOfSize(_ fontSize: CGFloat) -> UIFont {
+  private class func tvBoldFont(ofSize fontSize: CGFloat) -> UIFont {
     return UIFont(name: FontFamily.PingFangTCMedium, size: fontSize) ?? UIFont.boldSystemFont(ofSize: fontSize)
   }
 
   // MARK: - Public Methods
 
   class func tvFontForTagline() -> UIFont {
-    return UIFont.tvFontOfSize(44)
+    return UIFont.tvFont(ofSize: 44)
   }
 
   class func tvFontForCategoryCell() -> UIFont {
-    return UIFont.tvFontOfSize(35)
+    return UIFont.tvFont(ofSize: 35)
   }
 
   class func tvFontForFocusedCategoryCell() -> UIFont {
-    return UIFont.tvFontOfSize(40)
+    return UIFont.tvFont(ofSize: 40)
   }
 
   class func tvFontForVideoCell() -> UIFont {
-    return UIFont.tvFontOfSize(29)
+    return UIFont.tvFont(ofSize: 29)
   }
 
   class func tvFontForFocusedVideoCell() -> UIFont {
-    return UIFont.tvBoldFontOfSize(29)
+    return UIFont.tvBoldFont(ofSize: 29)
   }
 
   class func tvFontForVideoLength() -> UIFont {
@@ -70,15 +70,15 @@ extension UIFont {
   }
 
   class func tvFontForLogo() -> UIFont {
-    return UIFont.tvFontOfSize(65)
+    return UIFont.tvFont(ofSize: 65)
   }
 
   class func tvFontForMenuButton() -> UIFont {
-    return UIFont.tvFontOfSize(30)
+    return UIFont.tvFont(ofSize: 30)
   }
 
   class func tvFontForHeaderTitle() -> UIFont {
-    return UIFont.tvFontOfSize(35)
+    return UIFont.tvFont(ofSize: 35)
   }
 
 }

--- a/iCookTV/Extensions/UIImage+Grid.swift
+++ b/iCookTV/Extensions/UIImage+Grid.swift
@@ -28,13 +28,13 @@ import UIKit
 
 extension UIImage {
 
-  func image(byReplacingImage image: UIImage, atCorner corner: Grid) -> UIImage? {
+  func image(byReplacingImage image: UIImage, in grid: Grid) -> UIImage? {
     UIGraphicsBeginImageContextWithOptions(size, true, 0)
 
     let canvas = CGRect(origin: CGPoint.zero, size: size)
     self.draw(in: canvas)
 
-    let rect = canvas.rect(bySize: image.size, atCorner: corner)
+    let rect = canvas.rect(with: image.size, in: grid)
     image.draw(in: rect)
 
     let newImage = UIGraphicsGetImageFromCurrentImageContext()

--- a/iCookTV/Extensions/UIImage+Grid.swift
+++ b/iCookTV/Extensions/UIImage+Grid.swift
@@ -43,7 +43,7 @@ extension UIImage {
     return newImage
   }
 
-  class func placeholderImage(withSize size: CGSize) -> UIImage? {
+  class func placeholderImage(with size: CGSize) -> UIImage? {
     let layer = CAGradientLayer()
     layer.frame = CGRect(origin: CGPoint.zero, size: size)
     layer.colors = [UIColor.white.cgColor, UIColor.Palette.LightGray.cgColor]
@@ -63,7 +63,7 @@ extension UIImage {
     return image
   }
 
-  class func resizableImage(withFillColor color: UIColor) -> UIImage? {
+  class func resizableImage(filledWith color: UIColor) -> UIImage? {
     UIGraphicsBeginImageContextWithOptions(CGSize(width: 1, height: 1), true, 0)
 
     color.setFill()

--- a/iCookTV/Helpers/CoverBuilder.swift
+++ b/iCookTV/Helpers/CoverBuilder.swift
@@ -65,7 +65,7 @@ class CoverBuilder {
       if let currentImage = self?.cover, currentImage.size == imageSize {
         canvas = currentImage
       } else {
-        canvas = UIImage.placeholderImage(withSize: imageSize)
+        canvas = UIImage.placeholderImage(with: imageSize)
       }
 
       let cover = canvas?.image(byReplacingImage: image, in: grid)

--- a/iCookTV/Helpers/CoverBuilder.swift
+++ b/iCookTV/Helpers/CoverBuilder.swift
@@ -57,7 +57,7 @@ class CoverBuilder {
 
   // MARK: - Public Methods
 
-  func addImage(_ image: UIImage, atCorner corner: Grid, categoryID id: String? = nil, completion: @escaping (_ newCover: UIImage?) -> Void) {
+  func add(image: UIImage, to grid: Grid, categoryID id: String? = nil, completion: @escaping (_ newCover: UIImage?) -> Void) {
     operationQueue.addOperation(BlockOperation { [weak self] in
       let imageSize = CGSize(width: image.size.width * 2, height: image.size.height * 2)
       var canvas: UIImage?
@@ -68,9 +68,9 @@ class CoverBuilder {
         canvas = UIImage.placeholderImage(withSize: imageSize)
       }
 
-      let cover = canvas?.image(byReplacingImage: image, atCorner: corner)
+      let cover = canvas?.image(byReplacingImage: image, in: grid)
       self?.cover = cover
-      self?.filledGrids.insert(corner)
+      self?.filledGrids.insert(grid)
 
       if let key = id, let image = cover, self?.filledGrids.count == Grid.numberOfGrids {
         self?.cacheImage(image, forKey: key)

--- a/iCookTV/Models/CategoriesDataSource.swift
+++ b/iCookTV/Models/CategoriesDataSource.swift
@@ -38,7 +38,7 @@ class CategoriesDataSource: DataSource<CategoriesCollection> {
 
   override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
     let cell = collectionView.dequeueReusableCell(for: indexPath) as CategoryCell
-    cell.configure(withCategory: dataCollection[indexPath.row])
+    cell.configure(with: dataCollection[indexPath.row])
     return cell
   }
 

--- a/iCookTV/Models/VideosDataSource.swift
+++ b/iCookTV/Models/VideosDataSource.swift
@@ -50,7 +50,7 @@ class VideosDataSource: DataSource<VideosCollection> {
 
   override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
     let cell = collectionView.dequeueReusableCell(for: indexPath) as VideoCell
-    cell.configure(withVideo: dataCollection[indexPath.row])
+    cell.configure(with: dataCollection[indexPath.row])
     return cell
   }
 

--- a/iCookTV/Protocols/BlurBackgroundPresentable.swift
+++ b/iCookTV/Protocols/BlurBackgroundPresentable.swift
@@ -27,8 +27,8 @@
 import UIKit
 
 protocol BlurBackgroundPresentable: class {
-  /// A reference to the ImageAnimationQueue object that handles image transition.
-  var imageAnimationQueue: ImageAnimationQueue { get }
+  /// A reference to the background image view.
+  var backgroundImageView: UIImageView { get }
 
   /// Sets up the background image view with a blur effect on top of it.
   func setUpBlurBackground()
@@ -43,7 +43,6 @@ extension BlurBackgroundPresentable where Self: UIViewController {
   func setUpBlurBackground() {
     view.backgroundColor = UIColor.tvBackgroundColor()
 
-    let backgroundImageView = imageAnimationQueue.imageView
     backgroundImageView.frame = view.bounds
     backgroundImageView.contentMode = .scaleAspectFill
     backgroundImageView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
@@ -58,9 +57,9 @@ extension BlurBackgroundPresentable where Self: UIViewController {
 
   func animateBackgroundTransition(to image: UIImage?) {
     // Throttle background image transition to avoid extensive changes in a short period of time.
-    let selector = #selector(ImageAnimationQueue.animateBackgroundTransition(to:))
-    NSObject.cancelPreviousPerformRequests(withTarget: imageAnimationQueue, selector: selector, object: nil)
-    imageAnimationQueue.perform(selector, with: image, afterDelay: 0.2)
+    let selector = #selector(UIImageView.transition(to:))
+    NSObject.cancelPreviousPerformRequests(withTarget: backgroundImageView)
+    backgroundImageView.perform(selector, with: image, afterDelay: 0.2)
   }
 
 }
@@ -69,22 +68,16 @@ extension BlurBackgroundPresentable where Self: UIViewController {
 ////////////////////////////////////////////////////////////////////////////////
 
 
-class ImageAnimationQueue: NSObject {
+extension UIImageView {
 
-  fileprivate let imageView: UIImageView
-
-  init(imageView: UIImageView) {
-    self.imageView = imageView
-  }
-
-  @objc fileprivate func animateBackgroundTransition(to image: UIImage?) {
+  @objc fileprivate func transition(to image: UIImage?) {
     Debug.print(#function)
     UIView.transition(
-      with: imageView,
+      with: self,
       duration: 0.5,
       options: [.beginFromCurrentState, .transitionCrossDissolve, .curveEaseIn],
       animations: {
-        self.imageView.image = image
+        self.image = image
       }, completion: nil
     )
   }

--- a/iCookTV/Protocols/VideosGridLayout.swift
+++ b/iCookTV/Protocols/VideosGridLayout.swift
@@ -31,7 +31,7 @@ protocol VideosGridLayout: class {
   var collectionView: UICollectionView { get }
 
   /// Returns a configured collection view.
-  static func defaultLoadingIndicator() -> UIActivityIndicatorView
+  static func defaultCollectionView(dataSource: UICollectionViewDataSource, delegate: UICollectionViewDelegate) -> UICollectionView
 
   /// Sets up the collection view in the view hierarchy.
   func setUpCollectionView()

--- a/iCookTV/Views/CategoryCell.swift
+++ b/iCookTV/Views/CategoryCell.swift
@@ -118,21 +118,21 @@ class CategoryCell: UICollectionViewCell {
 
   func setUpCover(_ urls: [Grid: URL], forCategory category: Category) {
     // Cancel previous tasks
-    for (corner, task) in tasks {
+    for (grid, task) in tasks {
       task.cancel()
-      tasks[corner] = nil
+      tasks[grid] = nil
     }
 
-    for (corner, url) in urls {
+    for (grid, url) in urls {
       let downloading = ImageDownloader.default.downloadImage(with: url, progressBlock: nil) {
         [weak self] image, error, imageURL, originalData in
 
-        self?.tasks[corner] = nil
+        self?.tasks[grid] = nil
         guard let image = image, imageURL == url else {
           return
         }
 
-        self?.coverBuilder.addImage(image, atCorner: corner, categoryID: category.id) { newCover in
+        self?.coverBuilder.add(image: image, to: grid, categoryID: category.id) { newCover in
           if let current = self {
             UIView.transition(
               with: current.imageView,
@@ -146,7 +146,7 @@ class CategoryCell: UICollectionViewCell {
         }
       }
       if let task = downloading {
-        tasks[corner] = task
+        tasks[grid] = task
       }
     }
   }
@@ -163,8 +163,8 @@ class CategoryCell: UICollectionViewCell {
 
     var urls = [Grid: URL]()
     for (index, value) in category.coverURLs.enumerated() {
-      guard let corner = Grid(rawValue: index), let url = URL(string: value) else { continue }
-      urls[corner] = url
+      guard let grid = Grid(rawValue: index), let url = URL(string: value) else { continue }
+      urls[grid] = url
     }
 
     setUpCover(urls, forCategory: category)

--- a/iCookTV/Views/CategoryCell.swift
+++ b/iCookTV/Views/CategoryCell.swift
@@ -37,7 +37,7 @@ class CategoryCell: UICollectionViewCell {
 
   private(set) lazy var imageView: UIImageView = {
     let _imageView = UIImageView()
-    _imageView.image = UIImage.placeholderImage(withSize: self.bounds.size)
+    _imageView.image = UIImage.placeholderImage(with: self.bounds.size)
     _imageView.contentMode = .scaleAspectFill
     return _imageView
   }()
@@ -75,7 +75,7 @@ class CategoryCell: UICollectionViewCell {
       tasks[index] = nil
     }
     coverBuilder.resetCover()
-    imageView.image = UIImage.placeholderImage(withSize: bounds.size)
+    imageView.image = UIImage.placeholderImage(with: bounds.size)
     textLabel.text = nil
   }
 
@@ -153,7 +153,7 @@ class CategoryCell: UICollectionViewCell {
 
   // MARK: - Public Methods
 
-  func configure(withCategory category: Category) {
+  func configure(with category: Category) {
     textLabel.text = category.name
 
     if let cached = coverBuilder.coverForCategory(withID: category.id) {

--- a/iCookTV/Views/EmptyStateView.swift
+++ b/iCookTV/Views/EmptyStateView.swift
@@ -67,10 +67,10 @@ class EmptyStateView: UIView {
 
     imageView.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
 
-    let views = [
+    let views: [String: Any] = [
       "image": imageView,
       "text": textLabel
-    ] as [String : Any]
+    ]
     addConstraints(NSLayoutConstraint.constraints(
       withVisualFormat: "H:|-(>=0)-[image(280)]-(>=0)-|",
       options: [],

--- a/iCookTV/Views/MenuButton.swift
+++ b/iCookTV/Views/MenuButton.swift
@@ -44,8 +44,8 @@ class MenuButton: UIButton {
     contentEdgeInsets = UIEdgeInsets(top: 15, left: 40, bottom: 15, right: 40)
     setTitleColor(UIColor.Palette.Button.TitleColor, for: UIControlState())
     setTitleColor(UIColor.Palette.FocusedButton.TitleColor, for: .focused)
-    setImage(UIImage.resizableImage(withFillColor: UIColor.Palette.Button.BackgroundColor), for: .normal)
-    setImage(UIImage.resizableImage(withFillColor: UIColor.Palette.FocusedButton.BackgroundColor), for: .focused)
+    setImage(UIImage.resizableImage(filledWith: UIColor.Palette.Button.BackgroundColor), for: .normal)
+    setImage(UIImage.resizableImage(filledWith: UIColor.Palette.FocusedButton.BackgroundColor), for: .focused)
   }
 
 }

--- a/iCookTV/Views/VideoCell.swift
+++ b/iCookTV/Views/VideoCell.swift
@@ -31,7 +31,7 @@ class VideoCell: UICollectionViewCell {
 
   private(set) lazy var imageView: UIImageView = {
     let _imageView = UIImageView()
-    _imageView.image = UIImage.placeholderImage(withSize: self.bounds.size)
+    _imageView.image = UIImage.placeholderImage(with: self.bounds.size)
     _imageView.contentMode = .scaleAspectFill
     return _imageView
   }()
@@ -79,7 +79,7 @@ class VideoCell: UICollectionViewCell {
   override func prepareForReuse() {
     super.prepareForReuse()
     imageView.kf.cancelDownloadTask()
-    imageView.image = UIImage.placeholderImage(withSize: bounds.size)
+    imageView.image = UIImage.placeholderImage(with: bounds.size)
     titleLabel.text = nil
   }
 
@@ -138,9 +138,9 @@ class VideoCell: UICollectionViewCell {
 
   // MARK: - Public Methods
 
-  func configure(withVideo video: Video) {
+  func configure(with video: Video) {
     if let url = video.coverURL {
-      imageView.kf.setImage(with: url, placeholder: UIImage.placeholderImage(withSize: bounds.size))
+      imageView.kf.setImage(with: url, placeholder: UIImage.placeholderImage(with: bounds.size))
     }
     titleLabel.text = video.title
     timeLabel.text = video.timestamp


### PR DESCRIPTION
- [x] Follow the Swift [guideline](https://swift.org/documentation/api-design-guidelines/) to rename some of the methods
- [x] Use the background image view as the receiver instead of using another wrapper to perform methods after delay
- [x] Fix the background image transition cancelling by replacing `cancelPreviousPerformRequests(withTarget:selector:object:)` with `cancelPreviousPerformRequests(withTarget:)`

@polydice/ios could you please take a look at these changes? thanks!