### PR TITLE
Remove R.swift

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,8 +1,6 @@
 coverage:
   status:
-    project:
-      default:
-        threshold: 5%
+    project: off
     patch: off
     changes: off
 comment:

--- a/Podfile
+++ b/Podfile
@@ -14,7 +14,6 @@ target :iCookTV do
   pod "Freddy", "~> 3.0.0"
   pod "HCYoutubeParser"
   pod "Hue", "~> 2.0.0"
-  pod "R.swift", "~> 3.2.0"
   pod "Kingfisher", "~> 3.2.0"
   pod "TreasureData-iOS-SDK", "0.1.15"
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -11,9 +11,6 @@ PODS:
   - Kingfisher (3.2.4)
   - Nimble (7.0.3)
   - Quick (1.2.0)
-  - R.swift (3.2.0):
-    - R.swift.Library (~> 3.0.2)
-  - R.swift.Library (3.0.2)
   - SwiftLint (0.24.0)
   - TreasureData-iOS-SDK (0.1.15):
     - KeenClientTD (= 3.2.27)
@@ -29,7 +26,6 @@ DEPENDENCIES:
   - Kingfisher (~> 3.2.0)
   - Nimble
   - Quick
-  - R.swift (~> 3.2.0)
   - SwiftLint (= 0.24.0)
   - TreasureData-iOS-SDK (= 0.1.15)
 
@@ -49,11 +45,9 @@ SPEC CHECKSUMS:
   Kingfisher: 8d80f39da403cd9c9ee11984e1655f4d6a566cdb
   Nimble: 7f5a9c447a33002645a071bddafbfb24ea70e0ac
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
-  R.swift: 207a372a2b5977caef440c696a368009460641d1
-  R.swift.Library: fbdec16c9802ad104fc1ba53415dc190e6ec5c73
   SwiftLint: a014c92b4664e8b13f380f8640a51bb1733778ba
   TreasureData-iOS-SDK: cc878af36b85ae3540a9a5bdb36b7bdc8707b719
 
-PODFILE CHECKSUM: 890bc8cde488e1da70690561ca3f7dead572ce95
+PODFILE CHECKSUM: a39d73a29a507453d7f26041b291e321718ffeff
 
 COCOAPODS: 1.3.1

--- a/iCookTV.xcodeproj/project.pbxproj
+++ b/iCookTV.xcodeproj/project.pbxproj
@@ -52,7 +52,6 @@
 		B5A614F71CCA05B4004A3CD5 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = B5A614F91CCA05B4004A3CD5 /* InfoPlist.strings */; };
 		B5A8F7091CA259120069F836 /* CategoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A8F7081CA259120069F836 /* CategoryCell.swift */; };
 		B5AEEE321C82D4BC001CF112 /* Metrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5AEEE311C82D4BC001CF112 /* Metrics.swift */; };
-		B5BA3B4C1CF6D25500B0A022 /* R.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BA3B4B1CF6D25500B0A022 /* R.generated.swift */; };
 		B5BA61891C77431400548B38 /* VideoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BA61881C77431400548B38 /* VideoCell.swift */; };
 		B5BA618B1C7748B900548B38 /* Video.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BA618A1C7748B900548B38 /* Video.swift */; };
 		B5BA618D1C774BC400548B38 /* VideoPlayerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BA618C1C774BC400548B38 /* VideoPlayerController.swift */; };
@@ -133,7 +132,6 @@
 		B5A614FB1CCA05B7004A3CD5 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		B5A8F7081CA259120069F836 /* CategoryCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CategoryCell.swift; sourceTree = "<group>"; };
 		B5AEEE311C82D4BC001CF112 /* Metrics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Metrics.swift; sourceTree = "<group>"; };
-		B5BA3B4B1CF6D25500B0A022 /* R.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = R.generated.swift; sourceTree = "<group>"; };
 		B5BA61881C77431400548B38 /* VideoCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoCell.swift; sourceTree = "<group>"; };
 		B5BA618A1C7748B900548B38 /* Video.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Video.swift; sourceTree = "<group>"; };
 		B5BA618C1C774BC400548B38 /* VideoPlayerController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoPlayerController.swift; sourceTree = "<group>"; };
@@ -230,7 +228,6 @@
 				B5F7BF541BA9C95F00A75099 /* Info.plist */,
 				B5A614F91CCA05B4004A3CD5 /* InfoPlist.strings */,
 				B500D9A81CB94B5D00622198 /* Localizable.strings */,
-				B5BA3B4B1CF6D25500B0A022 /* R.generated.swift */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -374,7 +371,6 @@
 			buildPhases = (
 				24D096314DA4D14E4EDFA5EB /* [CP] Check Pods Manifest.lock */,
 				B52DFA9C1CF8006E005B9D67 /* Run Swiftlint */,
-				B5BA3B4A1CF6D19800B0A022 /* Run R.swift Script */,
 				B5F7BF441BA9C95F00A75099 /* Sources */,
 				B5F7BF451BA9C95F00A75099 /* Frameworks */,
 				B5F7BF461BA9C95F00A75099 /* Resources */,
@@ -540,7 +536,6 @@
 				"${BUILT_PRODUCTS_DIR}/KeenClientTD/KeenClientTD.framework",
 				"${BUILT_PRODUCTS_DIR}/Keys/Keys.framework",
 				"${BUILT_PRODUCTS_DIR}/Kingfisher/Kingfisher.framework",
-				"${BUILT_PRODUCTS_DIR}/R.swift.Library/Rswift.framework",
 				"${BUILT_PRODUCTS_DIR}/TreasureData-iOS-SDK/TreasureData_iOS_SDK.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -552,7 +547,6 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/KeenClientTD.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Keys.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Kingfisher.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Rswift.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TreasureData_iOS_SDK.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -588,20 +582,6 @@
 			shellPath = /bin/sh;
 			shellScript = "${PODS_ROOT}/SwiftLint/swiftlint --config ${SRCROOT}/.swiftlint.yml";
 		};
-		B5BA3B4A1CF6D19800B0A022 /* Run R.swift Script */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Run R.swift Script";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "sh ${SRCROOT}/scripts/rswift.sh";
-		};
 		D98BF45783F7971E01068E78 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -616,7 +596,6 @@
 				"${BUILT_PRODUCTS_DIR}/KeenClientTD/KeenClientTD.framework",
 				"${BUILT_PRODUCTS_DIR}/Keys/Keys.framework",
 				"${BUILT_PRODUCTS_DIR}/Kingfisher/Kingfisher.framework",
-				"${BUILT_PRODUCTS_DIR}/R.swift.Library/Rswift.framework",
 				"${BUILT_PRODUCTS_DIR}/TreasureData-iOS-SDK/TreasureData_iOS_SDK.framework",
 				"${BUILT_PRODUCTS_DIR}/Nimble/Nimble.framework",
 				"${BUILT_PRODUCTS_DIR}/Quick/Quick.framework",
@@ -630,7 +609,6 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/KeenClientTD.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Keys.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Kingfisher.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Rswift.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TreasureData_iOS_SDK.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nimble.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Quick.framework",
@@ -690,7 +668,6 @@
 				B5DA8EDE1CB3BD1B0068E0E3 /* MenuView.swift in Sources */,
 				B5AEEE321C82D4BC001CF112 /* Metrics.swift in Sources */,
 				B543C3EA1CD1E85E008C512B /* OverlayViewPresentable.swift in Sources */,
-				B5BA3B4C1CF6D25500B0A022 /* R.generated.swift in Sources */,
 				B55BF7E71DC5B7F400EE20BD /* Reusable.swift in Sources */,
 				B5C591151CA04BA50096B985 /* SectionHeaderView.swift in Sources */,
 				B516E78B1D54D73B00A3FCB9 /* SourceType.swift in Sources */,

--- a/iCookTV/Controllers/CategoriesViewController.swift
+++ b/iCookTV/Controllers/CategoriesViewController.swift
@@ -40,7 +40,7 @@ class CategoriesViewController: UIViewController,
 
   private lazy var titleView: MainMenuView = {
     let _menu = MainMenuView()
-    _menu.button.setTitle(R.string.localizable.history(), for: .normal)
+    _menu.button.setTitle(NSLocalizedString("history", comment: ""), for: .normal)
     _menu.button.addTarget(self, action: .showHistory, for: .primaryActionTriggered)
     return _menu
   }()

--- a/iCookTV/Controllers/HistoryViewController.swift
+++ b/iCookTV/Controllers/HistoryViewController.swift
@@ -57,7 +57,7 @@ class HistoryViewController: UIViewController,
 
   override var title: String? {
     get {
-      return R.string.localizable.history()
+      return NSLocalizedString("history", comment: "")
     }
     set {}  // swiftlint:disable:this unused_setter_value
   }
@@ -67,7 +67,7 @@ class HistoryViewController: UIViewController,
     setUpBlurBackground()
     setUpCollectionView()
     setUpDropdownMenuView()
-    dropdownMenuView.button.setTitle(R.string.localizable.home(), for: .normal)
+    dropdownMenuView.button.setTitle(NSLocalizedString("home", comment: ""), for: .normal)
     dropdownMenuView.button.addTarget(self, action: .backToHome, for: .primaryActionTriggered)
   }
 
@@ -126,7 +126,7 @@ class HistoryViewController: UIViewController,
 
   private(set) lazy var overlayView: UIView = {
     let _empty = EmptyStateView()
-    _empty.textLabel.text = R.string.localizable.noHistoryFound()
+    _empty.textLabel.text = NSLocalizedString("no-history-found", comment: "")
     return _empty
   }()
 

--- a/iCookTV/Controllers/LaunchViewController.swift
+++ b/iCookTV/Controllers/LaunchViewController.swift
@@ -32,7 +32,7 @@ class LaunchViewController: UIViewController, DataFetching {
 
   private lazy var launchImageView: UIImageView = {
     let _imageView = UIImageView()
-    _imageView.image = R.image.launchImage()
+    _imageView.image = UIImage(named: "launchImage")
     _imageView.contentMode = .scaleAspectFill
     return _imageView
   }()
@@ -46,13 +46,13 @@ class LaunchViewController: UIViewController, DataFetching {
 
   private lazy var upperTaglineLabel: UILabel = {
     let _upper = UILabel.taglineLabel()
-    _upper.text = R.string.localizable.launchScreenUpperTagline()
+    _upper.text = NSLocalizedString("launch-screen-upper-tagline", comment: "")
     return _upper
   }()
 
   private lazy var lowerTaglineLabel: UILabel = {
     let _lower = UILabel.taglineLabel()
-    _lower.text = R.string.localizable.launchScreenLowerTagline()
+    _lower.text = NSLocalizedString("launch-screen-lower-tagline", comment: "")
     return _lower
   }()
 

--- a/iCookTV/Controllers/VideoPlayerController.swift
+++ b/iCookTV/Controllers/VideoPlayerController.swift
@@ -155,9 +155,9 @@ class VideoPlayerController: AVPlayerViewController, Trackable {
     loadingIndicator.stopAnimating()
 
     guard let playerItem = playerItem else {
-      let message = R.string.localizable.videoError() + "\n" + R.string.localizable.contactInfo()
-      let alert = UIAlertController(title: R.string.localizable.errorTitle(), message: message, preferredStyle: .alert)
-      alert.addAction(UIAlertAction(title: R.string.localizable.ok(), style: .default) { [weak self] _ in
+      let message = NSLocalizedString("video-error", comment: "") + "\n" + NSLocalizedString("contact-info", comment: "")
+      let alert = UIAlertController(title: NSLocalizedString("error-title", comment: ""), message: message, preferredStyle: .alert)
+      alert.addAction(UIAlertAction(title: NSLocalizedString("ok", comment: ""), style: .default) { [weak self] _ in
         self?.dismiss()
       })
       present(alert, animated: true, completion: nil)

--- a/iCookTV/Controllers/VideosViewController.swift
+++ b/iCookTV/Controllers/VideosViewController.swift
@@ -89,7 +89,7 @@ class VideosViewController: UIViewController,
     setUpBlurBackground()
     setUpCollectionView()
     setUpDropdownMenuView()
-    dropdownMenuView.button.setTitle(R.string.localizable.history(), for: .normal)
+    dropdownMenuView.button.setTitle(NSLocalizedString("history", comment: ""), for: .normal)
     dropdownMenuView.button.addTarget(self, action: .showHistory, for: .primaryActionTriggered)
   }
 

--- a/iCookTV/Extensions/UIViewController+Alert.swift
+++ b/iCookTV/Extensions/UIViewController+Alert.swift
@@ -32,11 +32,11 @@ extension UIViewController {
     Tracker.track(error)
 
     let alert = UIAlertController(
-      title: R.string.localizable.errorTitle(),
-      message: R.string.localizable.contactInfo(),
+      title: NSLocalizedString("error-title", comment: ""),
+      message: NSLocalizedString("contact-info", comment: ""),
       preferredStyle: .alert
     )
-    alert.addAction(UIAlertAction(title: R.string.localizable.retry(), style: .default) { _ in
+    alert.addAction(UIAlertAction(title: NSLocalizedString("retry", comment: ""), style: .default) { _ in
       retry?()
     })
     present(alert, animated: true, completion: nil)

--- a/iCookTV/Views/EmptyStateView.swift
+++ b/iCookTV/Views/EmptyStateView.swift
@@ -30,7 +30,7 @@ class EmptyStateView: UIView {
 
   private(set) lazy var imageView: UIImageView = {
     let _imageView = UIImageView()
-    _imageView.image = R.image.icookTvCat()
+    _imageView.image = UIImage(named: "icook-tv-cat")
     _imageView.contentMode = .scaleAspectFill
     return _imageView
   }()
@@ -39,7 +39,7 @@ class EmptyStateView: UIView {
     let _label = UILabel()
     _label.font = UIFont.tvFontForTagline()
     _label.textColor = UIColor.tvTaglineColor()
-    _label.text = R.string.localizable.noVideoFound()
+    _label.text = NSLocalizedString("no-video-found", comment: "")
     _label.textAlignment = .center
     return _label
   }()

--- a/iCookTV/Views/MainMenuView.swift
+++ b/iCookTV/Views/MainMenuView.swift
@@ -28,15 +28,15 @@ import UIKit
 
 class MainMenuView: UIView {
 
-  private let frontBanner = UIImageView(image: R.image.icookTvBannerFoodFront())
-  private let backBanner = UIImageView(image: R.image.icookTvBannerFoodBack())
-  private let imageView = UIImageView(image: R.image.icookTvLogo())
+  private let frontBanner = UIImageView(image: UIImage(named: "icook-tv-banner-food-front"))
+  private let backBanner = UIImageView(image: UIImage(named: "icook-tv-banner-food-back"))
+  private let imageView = UIImageView(image: UIImage(named: "icook-tv-logo"))
 
   private(set) lazy var titleLabel: UILabel = {
     let _title = UILabel()
     _title.font = UIFont.tvFontForLogo()
     _title.textColor = UIColor.tvHeaderTitleColor()
-    _title.text = R.string.localizable.icookTv()
+    _title.text = NSLocalizedString("icook-tv", comment: "")
     return _title
   }()
 

--- a/iCookTV/Views/MenuView.swift
+++ b/iCookTV/Views/MenuView.swift
@@ -29,13 +29,13 @@ import UIKit
 /// A customized view with a layout of `H:|[focusGuide][button]-|`.
 class MenuView: UIView {
 
-  private let imageView = UIImageView(image: R.image.icookTvLogo())
+  private let imageView = UIImageView(image: UIImage(named: "icook-tv-logo"))
 
   private lazy var titleLabel: UILabel = {
     let _label = UILabel()
     _label.font = UIFont.tvFontForHeaderTitle()
     _label.textColor = UIColor.tvHeaderTitleColor()
-    _label.text = R.string.localizable.icookTv()
+    _label.text = NSLocalizedString("icook-tv", comment: "")
     return _label
   }()
 

--- a/iCookTV/Views/SectionHeaderView.swift
+++ b/iCookTV/Views/SectionHeaderView.swift
@@ -31,13 +31,13 @@ class SectionHeaderView: UICollectionReusableView {
 
   static let requiredHeight = CGFloat(140)
 
-  private let imageView = UIImageView(image: R.image.icookTvLogo())
+  private let imageView = UIImageView(image: UIImage(named: "icook-tv-logo"))
 
   private(set) lazy var titleLabel: UILabel = {
     let _title = UILabel()
     _title.font = UIFont.tvFontForHeaderTitle()
     _title.textColor = UIColor.tvHeaderTitleColor()
-    _title.text = R.string.localizable.icookTv()
+    _title.text = NSLocalizedString("icook-tv", comment: "")
     return _title
   }()
 

--- a/scripts/rswift.sh
+++ b/scripts/rswift.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-${PODS_ROOT}/R.swift/rswift ${SRCROOT}/iCookTV


### PR DESCRIPTION
This PR removes the dependency of R.swift, which caused a problem in some versions of Xcode and CocoaPods. Part the subsequent updates of #9.

✅ Remove R.swift
⬜️ Replace Freddy with Swift Codable
⬜️ Replace Quick and Nimble with XCTest
⬜️ Update the project to Xcode 10.3 with Swift 5

⚠️ ~~Not ready to merge until #9 is merged. The base branch needs to be updated.~~